### PR TITLE
Remove grunt daemon from Magento 2 template

### DIFF
--- a/templates/magento-2/docker-compose.yml
+++ b/templates/magento-2/docker-compose.yml
@@ -186,25 +186,6 @@ services:
     volumes:
       - es-data:/usr/share/elasticsearch/data:rw
 
-  grunt:
-    image: "eu.gcr.io/mct-deployments/magento-2-console:${PHP_VERSION}"
-    user: "${UID}:${GID}"
-    links:
-      - redis
-    network_mode: bridge
-    working_dir: "${PWD}"
-    command: grunt-daemon
-    environment: *env-vars
-    volumes:
-      - "${HOME}:${CHOME}"
-      - "${PWD}:${PWD}"
-
-  mailcatch:
-    image: mailhog/mailhog
-    network_mode: bridge
-    ports:
-      - "${MAILHOG_PORT}:8025"
-
   redis:
     image: redis:5.0-alpine
     network_mode: bridge


### PR DESCRIPTION
Since the grunt daemon is not working as expected when executing removing it. Grunt and NPM commands can still be executed from the docker console shell or from outside the console with: `dev run npm instal`, `dev run grunt exec`, `dev run grunt less` and `dev run grunt watch`