### PR TITLE
 Set version of docker-compose to 3.4

### DIFF
--- a/templates/alumio/docker-compose.yml
+++ b/templates/alumio/docker-compose.yml
@@ -1,5 +1,5 @@
 # vim: ai:ts=2:sw=2:et
-version: "3"
+version: "3.4"
 networks: {}
 volumes:
   db-data:


### PR DESCRIPTION
When using extensions the version must be 3.4. If not, the following
error is displayed:
    
Invalid top-level property "x-custom". Valid top-level sections for this
Compose file are: version, services, networks, volumes, and extensions
starting with "x-".