### PR TITLE
M2: Redis now has its own `volume` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.2.0]
+### Changed
+- M2: Redis now has its own `volume` so config cache and sessions persist between a `dev down && dev up`.
+
 ## [1.1.0]
 ### Changed
 - Instead of adding Rabbitmq-server this will also add a UI that can be reached using 

--- a/templates/magento-2/docker-compose.yml
+++ b/templates/magento-2/docker-compose.yml
@@ -5,6 +5,7 @@ networks:
 volumes:
   db-data:
   es-data:
+  redis-data:
 
 x-custom:
   version: 1.2.0
@@ -210,6 +211,9 @@ services:
 
   redis:
     image: redis:5.0-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
     networks:
       - backend
 


### PR DESCRIPTION
so config cache and sessions persist between a `dev down && dev up`.