### PR TITLE
refactor: move every function and command to a dedicated file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# PhpStorm / IDEA
+.idea
+# NetBeans
+nbproject
+# VS Code
+.prettierrc.js

--- a/commands/attach
+++ b/commands/attach
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+# Turn on and attach to specified container
+command_register attach 'Turn on and attach to specified container'
+
+attach_help() {
+  echo "Attach to a container."
+  echo "Usage: $0 attach <container-name>"
+  return 0
+}
+
+attach_command() {
+  $DC up "$1"
+  return $?
+}
+

--- a/commands/logs
+++ b/commands/logs
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+# Turn on and attach to specified container
+command_register logs 'Display container output logs'
+
+logs_help() {
+  echo "Display container output logs."
+  echo "Usage: $0 logs [-f] [service]"
+  echo "For more info, see: docker-compose help logs"
+  return 0
+}
+
+logs_command() {
+  $DC logs "$@"
+  return $?
+}
+

--- a/commands/test
+++ b/commands/test
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+command_register test 'Just a test'
+
+test_help() {
+  echo "Just a test command"
+  return 0
+}
+
+test_command() {
+  echo "Hello world! ($1)"
+  return 0
+}

--- a/dev
+++ b/dev
@@ -1,134 +1,32 @@
 #!/usr/bin/env bash
 # vim: et:sw=2:ts=2:ai
 
-# Load environment variables
-load_env() {
-  # We use "tr" to translate the uppercase "uname" output into lowercase
-  UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
-  # Then we map the output to the names used on the Github releases page
-  case "$UNAME" in
-      linux*)     MACHINE=linux;;
-      darwin*)    MACHINE=macos;;
-      mingw*)     MACHINE=windows;;
-  esac
-  export MACHINE
+# In this section only functions to boot the program
 
-  # OSX requires coreutils
-  if [[ "${MACHINE}" == "macos" ]] && ! which gtouch > /dev/null; then
-    echo "Required tools are missing, please run: brew install coreutils"
-    exit 1
-  fi
-
-  if [[ "${MACHINE}" == "macos" ]]; then
-    touch() {
-      gtouch "$@"
-    }
-  fi
-
-  # Set the default environment
-  export SPECIFIED_ENV=dev
-
-  # Ensure the docker host is accessible
-  if [[ "${MACHINE}" == "windows" ]]; then
-    HOST_IP=host.docker.internal
-  elif [[ "${MACHINE}" == "macos" ]]; then
-    HOST_IP=host.docker.internal
-  else
-    HOST_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
-  fi
-  export HOST_IP
-
-  # Ensure an SSH socket is available
-  if [[ "$SSH_AUTH_SOCK" == "" ]]; then
-    SSH_AUTH_SOCK="/tmp/.ssh-sock"
-    ssh-agent -a "${SSH_AUTH_SOCK}"
-  fi
-  export SSH_AUTH_SOCK
-
-  source_env "${APP_PROJECT_PATH}"
-
-  PROJECT="${APP_PROJECT}"
-  export PROJECT
-
-  CACHE_DIR="${HOME}/.cache/development-manager-docker-compose"
-  export CACHE_DIR
-
-  GID=$(id -g)
-  export GID
-  export UID
-  if [[ "${MACHINE}" == "windows" ]]; then
-    DC="winpty docker-compose"
-    CUID="1000"
-    CGID="1000"
-    CHOME="/home/app"
-  else
-    DC="docker-compose"
-    CUID="${UID}"
-    CGID="${GID}"
-    CHOME="${HOME}"
-  fi
-  export CUID
-  export CGID
-  export CHOME
+# Running dev in debug mode: export YOUWE_DEV_DEBUG=1; dev <command>
+# Function usage: debug <component> <message>
+debug() {
+  (($YOUWE_DEV_DEBUG)) && printf 'DEBUG%-15s %s\n' "[${1^^}]" "$2"
 }
 
-function parse_yaml {
-   local prefix=$2
-   local s='[[:space:]]*' w='[a-zA-Z0-9_\-]*' fs=$(echo @|tr @ '\034')
-   sed -ne "s|^\($s\):|\1|" \
-        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
-        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
-   awk -F$fs '{
-      indent = length($1)/2;
-      vname[indent] = $2;
-      for (i in vname) {if (i > indent) {delete vname[i]}}
-      if (length($3) > 0) {
-         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-         sub(/-/, "_", vn)
-         sub(/-/, "_", $2)
-         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
-      }
-   }'
+autoload() {
+  autoload_dir "$APP_SELF_PATH"/functions
+  autoload_dir "$APP_SELF_PATH"/commands
 }
 
-source_env() {
-  # Configure .env files
-  local env="${1}/.env"
-  local env_local="${1}/.env.local"
+autoload_dir() {
+  local dir="$1"
 
-  # Load all variables as if they are exported
-  set -a
+  for file in "$dir"/*; do
+    if [ -d "$file" ]; then
+      # Recursive load
+      autoload_dir "$file"
+      continue
+    fi
 
-  # Check and load if environment .env file exists
-  # shellcheck source=.env
-  if [ -e "$env" ]; then
-    source "$env"
-  fi
-
-  # Check and load if environment local .env file exists
-  # shellcheck source=.env.local
-  if [ -e "$env_local" ]; then
-    source "$env_local"
-  fi
-
-  # Configure .env files for specified SPECIFIED_ENV
-  local specified_env="${1}/.env.${SPECIFIED_ENV}"
-  local specified_env_local="${1}/.env.${SPECIFIED_ENV}.local"
-
-  # Check and load if environment specific .env file exists
-  # shellcheck source=.env.dev
-  if [ -e "$specified_env" ]; then
-    source "$specified_env"
-  fi
-
-  # Check and load if environment specific local .env file exists
-  # shellcheck source=.env.dev.local
-  if [ -e "$specified_env_local" ]; then
-    source "$specified_env_local"
-  fi
-
-  # Don't automatically export set variables
-  set +a
+    debug "autoload" "Loading file $file..."
+    source "$file"
+  done
 }
 
 # Container for all supported commands
@@ -138,6 +36,8 @@ run() {
   APP_SELF_PATH=$(dirname "$(realpath "$0")")
   APP_PROJECT_PATH=$(pwd)
   APP_PROJECT=$(basename "${APP_SELF_PATH}")
+
+  autoload
 
   # Turn on and attach to specified container
   attach() {
@@ -375,6 +275,10 @@ run() {
       echo "  run: Run a command"
       echo "  selfupdate: Run self update"
       echo "  up: Start the environment"
+
+      echo
+      echo
+      command_list
     fi
     return $?
   }
@@ -462,6 +366,15 @@ run() {
     $DC up -d "$@"
     return $?
   }
+
+  if command_exists "$1" ; then
+    local command_method="${1}_command"
+    shift
+
+    debug "run" "Running $command_method $@"
+    $command_method "$@"
+    return $?
+  fi
 
   # Attempt to run a command or output the help
   if [ "$(type -t "$1")" == "function" ]; then

--- a/functions/commands
+++ b/functions/commands
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+# Note: associative array needs to be declared in global scope (otherwise unsupported in bash)
+declare -gA command_data
+
+command_register() {
+  local name="$1"
+  local description="$2"
+
+  debug "command" "Registering command '$name'"
+  command_data[$name]="$description"
+}
+
+command_list() {
+  local command
+
+  echo "The following commands are available:"
+  for command in "${!command_data[@]}"; do
+    printf '  %-20s %s\n' "$command" "${command_data[$command]}"
+  done
+}
+
+command_exists() {
+  contains_element "$1" "${!command_data[@]}"
+  return $?
+}

--- a/functions/contains_element
+++ b/functions/contains_element
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+# contains_element "$searchTerm" "${arrayVariable[@]"
+# source: https://stackoverflow.com/a/8574392
+contains_element() {
+  local element`` search="$1"
+
+  shift
+  for element; do
+    [[ "$element" == "$search" ]] && return 0
+  done
+
+  return 1
+}

--- a/functions/load_env
+++ b/functions/load_env
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+# Load environment variables
+load_env() {
+  # We use "tr" to translate the uppercase "uname" output into lowercase
+  UNAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+  # Then we map the output to the names used on the Github releases page
+  case "$UNAME" in
+      linux*)     MACHINE=linux;;
+      darwin*)    MACHINE=macos;;
+      mingw*)     MACHINE=windows;;
+  esac
+  export MACHINE
+
+  # OSX requires coreutils
+  if [[ "${MACHINE}" == "macos" ]] && ! which gtouch > /dev/null; then
+    echo "Required tools are missing, please run: brew install coreutils"
+    exit 1
+  fi
+
+  if [[ "${MACHINE}" == "macos" ]]; then
+    touch() {
+      gtouch "$@"
+    }
+  fi
+
+  # Set the default environment
+  export SPECIFIED_ENV=dev
+
+  # Ensure the docker host is accessible
+  if [[ "${MACHINE}" == "windows" ]]; then
+    HOST_IP=host.docker.internal
+  elif [[ "${MACHINE}" == "macos" ]]; then
+    HOST_IP=host.docker.internal
+  else
+    HOST_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+  fi
+  export HOST_IP
+
+  # Ensure an SSH socket is available
+  if [[ "$SSH_AUTH_SOCK" == "" ]]; then
+    SSH_AUTH_SOCK="/tmp/.ssh-sock"
+    ssh-agent -a "${SSH_AUTH_SOCK}"
+  fi
+  export SSH_AUTH_SOCK
+
+  source_env "${APP_PROJECT_PATH}"
+
+  PROJECT="${APP_PROJECT}"
+  export PROJECT
+
+  CACHE_DIR="${HOME}/.cache/development-manager-docker-compose"
+  export CACHE_DIR
+
+  GID=$(id -g)
+  export GID
+  export UID
+  if [[ "${MACHINE}" == "windows" ]]; then
+    DC="winpty docker-compose"
+    CUID="1000"
+    CGID="1000"
+    CHOME="/home/app"
+  else
+    DC="docker-compose"
+    CUID="${UID}"
+    CGID="${GID}"
+    CHOME="${HOME}"
+  fi
+  export CUID
+  export CGID
+  export CHOME
+}

--- a/functions/parse_yaml
+++ b/functions/parse_yaml
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+parse_yaml() {
+   local prefix=$2
+   local s='[[:space:]]*' w='[a-zA-Z0-9_\-]*' fs=$(echo @|tr @ '\034')
+   sed -ne "s|^\($s\):|\1|" \
+        -e "s|^\($s\)\($w\)$s:$s[\"']\(.*\)[\"']$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s:$s\(.*\)$s\$|\1$fs\2$fs\3|p"  $1 |
+   awk -F$fs '{
+      indent = length($1)/2;
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+         vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+         sub(/-/, "_", vn)
+         sub(/-/, "_", $2)
+         printf("%s%s%s=\"%s\"\n", "'$prefix'",vn, $2, $3);
+      }
+   }'
+}

--- a/functions/source_env
+++ b/functions/source_env
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# vim: et:sw=2:ts=2:ai
+
+source_env() {
+  # Configure .env files
+  local env="${1}/.env"
+  local env_local="${1}/.env.local"
+
+  # Load all variables as if they are exported
+  set -a
+
+  # Check and load if environment .env file exists
+  # shellcheck source=.env
+  if [ -e "$env" ]; then
+    source "$env"
+  fi
+
+  # Check and load if environment local .env file exists
+  # shellcheck source=.env.local
+  if [ -e "$env_local" ]; then
+    source "$env_local"
+  fi
+
+  # Configure .env files for specified SPECIFIED_ENV
+  local specified_env="${1}/.env.${SPECIFIED_ENV}"
+  local specified_env_local="${1}/.env.${SPECIFIED_ENV}.local"
+
+  # Check and load if environment specific .env file exists
+  # shellcheck source=.env.dev
+  if [ -e "$specified_env" ]; then
+    source "$specified_env"
+  fi
+
+  # Check and load if environment specific local .env file exists
+  # shellcheck source=.env.dev.local
+  if [ -e "$specified_env_local" ]; then
+    source "$specified_env_local"
+  fi
+
+  # Don't automatically export set variables
+  set +a
+}


### PR DESCRIPTION
Just a DRAFT pull request for now and at this moment highly WORK-IN-PROGRESS!!!

Within our Pimcore team we have several docker-scripts that are stored within project repositories. So they are duplicated and therefore not maintainable. I want to move to your dev setup but also don't want to lose my (Pimcore-specific) commands also.

So for now migrating the current dev-script to a more one-file-per-command setup. After that I want to add a plugin option so we can add project-type specific commands to the dev tool as well.