### PR TITLE
Rabbitmq queues are now persistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.1]
+### Added
+- M2: Rabbitmq now has its own `volume` and hostname so queues persist between a `dev down && dev up`.
+
 ## [1.3.0]
 ### Added
 - Extended PHP environment for generic use that is more inline with the current magento stack.

--- a/templates/magento-2/docker-compose.yml
+++ b/templates/magento-2/docker-compose.yml
@@ -6,6 +6,7 @@ volumes:
   db-data:
   es-data:
   redis-data:
+  amqp-data:
 
 x-custom:
   version: 1.2.0
@@ -85,6 +86,7 @@ x-custom:
 
 services:
   amqp:
+    hostname: amqp
     image: rabbitmq:3-management-alpine
     networks:
       - backend
@@ -95,6 +97,8 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
+    volume:
+      - amqp-data:/var/lib/rabbitmq/
 
   console:
     image: "eu.gcr.io/mct-deployments/magento-2-console:${PHP_VERSION}"

--- a/templates/magento-2/docker-compose.yml
+++ b/templates/magento-2/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     ports:
       - 5672:5672
       - 15672:15672
-    volume:
+    volumes:
       - amqp-data:/var/lib/rabbitmq/
 
   console:


### PR DESCRIPTION
Hostname is necessary to make the queues persistent. Rabbitmq generates a random hash hostname on each boot otherwise.