### PR TITLE
Workaround for no GID variable

### DIFF
--- a/dev
+++ b/dev
@@ -64,8 +64,12 @@ load_env() {
   else
     DC="docker-compose"
     CUID="${UID}"
-    CGID="${GID}"
     CHOME="${HOME}"
+    if [[ "${MACHINE}" == "linux" ]]; then
+      CGID=`id -gn`
+    else
+      CGID="${GID}"
+    fi
   fi
   export CUID
   export CGID


### PR DESCRIPTION
On any Ubuntu machine with `bash`, I get the errors because the `GID` variable is never set. See the following discussion as well: https://askubuntu.com/questions/1124674/why-is-my-gid-environment-variable-empty The fix here is to use `id -gn` instead.