### PR TITLE
Fix interface name under Ubuntu in WSL (Windows)

### DIFF
--- a/dev
+++ b/dev
@@ -34,7 +34,9 @@ load_env() {
   elif [[ "${MACHINE}" == "macos" ]]; then
     HOST_IP=host.docker.internal
   else
-    HOST_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+    WSL=`grep -qEi "(Microsoft|WSL)" /proc/version`
+    [[ $WSL ]] ?? INTERFACE="eth0" || INTERFACE="docker0"
+    HOST_IP=$(ip -4 addr show $INTERFACE | grep -Po 'inet \K[\d.]+')
   fi
   export HOST_IP
 


### PR DESCRIPTION
When running Ubuntu inside the WSL, there is no interface `docker0` available and because of this, the `HOST_IP` is never set properly by the `dev` script. This PR fixes this by using the `eth0` interface instead, when the WSL is detected.