### PR TITLE
fix | DNS_NAME for magento 2 projects updated

### DIFF
--- a/templates/magento-2/.env.dev
+++ b/templates/magento-2/.env.dev
@@ -7,7 +7,7 @@ GCLOUD_BUCKET_URL_MEDIA="gs://<BUCKET_NAME>/fixtures/media.tgz"
 ################################################################################
 # DNS configuration                                                            #
 ################################################################################
-DNS_NAME="<SUBDOMAIN>.dev.mediacthq.nl"
+DNS_NAME="<SUBDOMAIN>.youweagency.dev"
 
 ################################################################################
 # Remaining configuration                                                      #


### PR DESCRIPTION
All projects should use .youweagency.dev.
By updating this in the env.dev all new projects will now use this in the URL.